### PR TITLE
leaky tests

### DIFF
--- a/test.c
+++ b/test.c
@@ -35,6 +35,7 @@ test_list_node_new() {
   char *val = "some value";
   list_node_t *node = list_node_new(val);
   assert(node->val == val);
+  free(node);
 }
 
 static void
@@ -51,15 +52,17 @@ test_list_rpush() {
   list_rpush(list, c);
 
   // Assertions
-  assert(list->head == a);
-  assert(list->tail == c);
-  assert(list->len == 3);
-  assert(a->next == b);
-  assert(a->prev == NULL);
-  assert(b->next == c);
-  assert(b->prev == a);
-  assert(c->next == NULL);
-  assert(c->prev == b);
+  assert(a == list->head);
+  assert(c == list->tail);
+  assert(3 == list->len);
+  assert(b == a->next);
+  assert(NULL == a->prev);
+  assert(c == b->next);
+  assert(a == b->prev);
+  assert(NULL == c->next);
+  assert(b == c->prev);
+
+  list_destroy(list);
 }
 
 static void
@@ -76,15 +79,17 @@ test_list_lpush() {
   list_lpush(list, c);
 
   // Assertions
-  assert(list->head == c);
-  assert(list->tail == a);
-  assert(list->len == 3);
-  assert(a->next == NULL);
-  assert(a->prev == b);
-  assert(b->next == a);
-  assert(b->prev == c);
-  assert(c->next == b);
-  assert(c->prev == NULL);
+  assert(c == list->head);
+  assert(a == list->tail);
+  assert(3 == list->len);
+  assert(NULL == a->next);
+  assert(b == a->prev);
+  assert(a == b->next);
+  assert(c == b->prev);
+  assert(b == c->next);
+  assert(NULL == c->prev);
+
+  list_destroy(list);
 }
 
 static void
@@ -110,6 +115,8 @@ test_list_at() {
   assert(b == list_at(list, -2));
   assert(a == list_at(list, -3));
   assert(NULL == list_at(list, -4));
+
+  list_destroy(list);
 }
 
 static void
@@ -132,7 +139,7 @@ test_list_destroy() {
   list_rpush(c, list_node_new(list_node_new("b")));
   list_rpush(c, list_node_new(list_node_new("c")));
   list_destroy(c);
-  assert(freeProxyCalls == 3);
+  assert(3 == freeProxyCalls);
 }
 
 static void
@@ -154,16 +161,20 @@ test_list_find() {
   list_node_t *a = list_find(langs, "js");
   list_node_t *b = list_find(langs, "ruby");
   list_node_t *c = list_find(langs, "foo");
-  assert(a == js);
-  assert(b == ruby);
-  assert(c == NULL);
+  assert(js == a);
+  assert(ruby == b);
+  assert(NULL == c);
+
+  list_destroy(langs);
 
   a = list_find(users, &userTJ);
   b = list_find(users, &userSimon);
   c = list_find(users, &userTaylor);
-  assert(a == tj);
-  assert(b == simon);
-  assert(c == NULL);
+  assert(tj == a);
+  assert(simon == b);
+  assert(NULL == c);
+
+  list_destroy(users);
 }
 
 static void
@@ -175,28 +186,30 @@ test_list_remove() {
   list_node_t *c = list_rpush(list, list_node_new("c"));
 
   // Assertions
-  assert(list->len == 3);
+  assert(3 == list->len);
 
   list_remove(list, b);
-  assert(list->len == 2);
-  assert(list->head == a);
-  assert(list->tail == c);
-  assert(a->next == c);
-  assert(a->prev == NULL);
-  assert(c->next == NULL);
-  assert(c->prev == a);
+  assert(2 == list->len);
+  assert(a == list->head);
+  assert(c == list->tail);
+  assert(c == a->next);
+  assert(NULL == a->prev);
+  assert(NULL == c->next);
+  assert(a == c->prev);
 
   list_remove(list, a);
-  assert(list->len == 1);
-  assert(list->head == c);
-  assert(list->tail == c);
-  assert(c->next == NULL);
-  assert(c->prev == NULL);
+  assert(1 == list->len);
+  assert(c == list->head);
+  assert(c == list->tail);
+  assert(NULL == c->next);
+  assert(NULL == c->prev);
 
   list_remove(list, c);
-  assert(list->len == 0);
-  assert(list->head == NULL);
-  assert(list->tail == NULL);
+  assert(0 == list->len);
+  assert(NULL == list->head);
+  assert(NULL == list->tail);
+
+  list_destroy(list);
 }
 
 static void
@@ -219,18 +232,26 @@ test_list_rpop() {
   assert(NULL == c->prev && "detached node prev is not NULL");
   assert(NULL == c->next && "detached node next is not NULL");
 
+  free(c);
+
   assert(b == list_rpop(list));
   assert(1 == list->len);
   assert(a == list->head);
   assert(a == list->tail);
+
+  free(b);
 
   assert(a == list_rpop(list));
   assert(0 == list->len);
   assert(NULL == list->head);
   assert(NULL == list->tail);
 
+  free(a);
+
   assert(NULL == list_rpop(list));
   assert(0 == list->len);
+
+  list_destroy(list);
 }
 
 static void
@@ -251,16 +272,24 @@ test_list_lpop() {
   assert(NULL == a->prev && "detached node prev is not NULL");
   assert(NULL == a->next && "detached node next is not NULL");
 
+  free(a);
+
   assert(b == list_lpop(list));
   assert(1 == list->len);
+
+  free(b);
 
   assert(c == list_lpop(list));
   assert(0 == list->len);
   assert(NULL == list->head);
   assert(NULL == list->tail);
 
+  free(c);
+
   assert(NULL == list_lpop(list));
   assert(0 == list->len);
+
+  list_destroy(list);
 }
 
 static void
@@ -288,7 +317,9 @@ test_list_iterator_t() {
   assert(a == tj);
   assert(b == taylor);
   assert(c == simon);
-  assert(d == NULL);
+  assert(NULL == d);
+
+  list_iterator_destroy(it);
 
   // From tail
   it = list_iterator_new(list, LIST_TAIL);
@@ -300,8 +331,10 @@ test_list_iterator_t() {
   assert(a2 == simon);
   assert(b2 == taylor);
   assert(c2 == tj);
-  assert(d2 == NULL);
+  assert(NULL == d2);
   list_iterator_destroy(it);
+
+  list_destroy(list);
 }
 
 int


### PR DESCRIPTION
tests are leaking a lot, making it extremely difficult to see if the lib itself is leaking.

there are still a few leaks left...

```
$ valgrind bin/test
==10935== Memcheck, a memory error detector
==10935== Copyright (C) 2002-2011, and GNU GPL'd, by Julian Seward et al.
==10935== Using Valgrind-3.7.0 and LibVEX; rerun with -h for copyright info
==10935== Command: bin/test
==10935== 

list_t: 40
list_node_t: 24
list_iterator_t: 16

... list_node_new
... list_rpush
... list_lpush
... list_find
... list_at
... list_remove
... list_rpop
... list_lpop
... list_destroy
... list_iterator_t
... 100%

==10935== 
==10935== HEAP SUMMARY:
==10935==     in use at exit: 256 bytes in 10 blocks
==10935==   total heap usage: 61 allocs, 51 frees, 1,544 bytes allocated
==10935== 
==10935== LEAK SUMMARY:
==10935==    definitely lost: 184 bytes in 7 blocks
==10935==    indirectly lost: 72 bytes in 3 blocks
==10935==      possibly lost: 0 bytes in 0 blocks
==10935==    still reachable: 0 bytes in 0 blocks
==10935==         suppressed: 0 bytes in 0 blocks
==10935== Rerun with --leak-check=full to see details of leaked memory
==10935== 
==10935== For counts of detected and suppressed errors, rerun with: -v
==10935== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 2 from 2)
```
