### PR TITLE
Update list.h to allow configuration header set up LIST macros

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -12,7 +12,7 @@
  */
 
 list_t *
-list_new() {
+list_new(void) {
   list_t *self;
   if (!(self = LIST_MALLOC(sizeof(list_t))))
     return NULL;

--- a/src/list.h
+++ b/src/list.h
@@ -83,7 +83,7 @@ list_node_new(void *val);
 // list_t prototypes.
 
 list_t *
-list_new();
+list_new(void);
 
 list_node_t *
 list_rpush(list_t *self, list_node_t *node);

--- a/src/list.h
+++ b/src/list.h
@@ -19,6 +19,13 @@ extern "C" {
 #define LIST_VERSION "0.0.5"
 
 // Memory management macros
+#ifdef LIST_CONFIG_H
+#define _STR(x) #x
+#define STR(x) _STR(x)
+#include STR(LIST_CONFIG_H)
+#undef _STR
+#undef STR
+#endif
 
 #ifndef LIST_MALLOC
 #define LIST_MALLOC malloc

--- a/src/list.h
+++ b/src/list.h
@@ -5,8 +5,8 @@
 // Copyright (c) 2010 TJ Holowaychuk <tj@vision-media.ca>
 //
 
-#ifndef LIST_H
-#define LIST_H
+#ifndef __CLIBS_LIST_H__
+#define __CLIBS_LIST_H__
 
 #ifdef __cplusplus
 extern "C" {
@@ -127,4 +127,4 @@ list_iterator_destroy(list_iterator_t *self);
 }
 #endif
 
-#endif /* LIST_H */
+#endif /* __CLIBS_LIST_H__ */


### PR DESCRIPTION
Add:
- capability to provide `LIST_CONFIG_H` header that overwrites `LIST_MALLOC` and `LIST_FREE` macros
- noticeable include guard to avoid common naming conflict

Fix:
- `list_new()` signature to specify `void` as argument, as function with empty braces `()` is valid in C++, but not in C

fix #26 