### PR TITLE
Fix freeProxyCalls and add comment in list.c

### DIFF
--- a/src/list.c
+++ b/src/list.c
@@ -26,6 +26,7 @@ list_new(void) {
 
 /*
  * Free the list.
+ * @self: Pointer to the list 
  */
 
 void
@@ -47,6 +48,8 @@ list_destroy(list_t *self) {
 /*
  * Append the given node to the list
  * and return the node, NULL on failure.
+ * @self: Pointer to the list for popping node
+ * @node: the node to push
  */
 
 list_node_t *
@@ -69,6 +72,7 @@ list_rpush(list_t *self, list_node_t *node) {
 
 /*
  * Return / detach the last node in the list, or NULL.
+ * @self: Pointer to the list for popping node
  */
 
 list_node_t *
@@ -89,6 +93,7 @@ list_rpop(list_t *self) {
 
 /*
  * Return / detach the first node in the list, or NULL.
+ * @self: Pointer to the list for popping node
  */
 
 list_node_t *
@@ -110,6 +115,8 @@ list_lpop(list_t *self) {
 /*
  * Prepend the given node to the list
  * and return the node, NULL on failure.
+ * @self: Pointer to the list for pushing node
+ * @node: the node to push
  */
 
 list_node_t *
@@ -132,6 +139,8 @@ list_lpush(list_t *self, list_node_t *node) {
 
 /*
  * Return the node associated to val or NULL.
+ * @self: Pointer to the list for finding given value
+ * @val: Value to find 
  */
 
 list_node_t *
@@ -159,6 +168,8 @@ list_find(list_t *self, void *val) {
 
 /*
  * Return the node at the given index or NULL.
+ * @self: Pointer to the list for finding given index 
+ * @index: the index of node in the list
  */
 
 list_node_t *
@@ -183,6 +194,8 @@ list_at(list_t *self, int index) {
 
 /*
  * Remove the given node from the list, freeing it and it's value.
+ * @self: Pointer to the list to delete a node 
+ * @node: Pointer the node to be deleted
  */
 
 void


### PR DESCRIPTION
In test.c ,when list_destroy greater than 2 times and doing assert , it won't have correct freeProxyCalls.

![Test_bug](https://user-images.githubusercontent.com/73817114/147570639-6101c54d-cc93-446d-a151-d2be42cb11cf.png)

Therefore, every time initialize freeProxyCalls is essential.
Add Comment about parameter in list.c.