### PR TITLE
Makefile enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ PREFIX ?= /usr/local
 DESTDIR ?=
 
 CFLAGS = -O3 -std=c99 -Wall -Wextra -Ideps
+LDFLAGS ?= -Wl,-z,now
 
 SRCS = src/list.c \
 		   src/list_node.c \
@@ -39,7 +40,7 @@ build/liblist.a: $(OBJS)
 
 build/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION): $(OBJS)
 	@mkdir -p build
-	ld -z now -shared -lc -soname `basename $@` src/*.o -o $@
+	$(CC) $(LDFLAGS) -shared -lc -Wl,-soname,`basename $@` src/*.o -o $@
 	$(STRIP) --strip-unneeded --remove-section=.comment --remove-section=.note $@
 
 bin/test: test.o $(OBJS)

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ CC ?= gcc
 STRIP ?= strip
 PREFIX ?= /usr/local
 LIBDIR ?= $(PREFIX)/lib
+INCLUDEDIR ?= $(PREFIX)/include
 DESTDIR ?=
 
 CFLAGS = -O3 -std=c99 -Wall -Wextra -Ideps
@@ -28,12 +29,12 @@ install: all
 	ln -sf liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION) $(DESTDIR)$(LIBDIR)/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION)
 	ln -sf liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION) $(DESTDIR)$(LIBDIR)/liblist.so.$(MAJOR_VERSION)
 	ln -sf liblist.so.$(MAJOR_VERSION) $(DESTDIR)$(LIBDIR)/liblist.so
-	test -d $(DESTDIR)$(PREFIX)/include || mkdir -p $(DESTDIR)$(PREFIX)/include/
-	cp -f src/list.h $(DESTDIR)$(PREFIX)/include/list.h
+	test -d $(DESTDIR)$(INCLUDEDIR) || mkdir -p $(DESTDIR)$(INCLUDEDIR)/
+	cp -f src/list.h $(DESTDIR)$(INCLUDEDIR)/list.h
 
 uninstall:
 	rm -f $(DESTDIR)$(LIBDIR)/liblist.a
-	rm -f $(DESTDIR)$(PREFIX)/include/list.h
+	rm -f $(DESTDIR)$(INCLUDEDIR)/list.h
 
 build/liblist.a: $(OBJS)
 	@mkdir -p build

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ AR ?= ar
 CC ?= gcc
 STRIP ?= strip
 PREFIX ?= /usr/local
+LIBDIR ?= $(PREFIX)/lib
 DESTDIR ?=
 
 CFLAGS = -O3 -std=c99 -Wall -Wextra -Ideps
@@ -21,17 +22,17 @@ PATCH_VERSION = 0
 all: build/liblist.a build/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)
 
 install: all
-	test -d $(DESTDIR)$(PREFIX)/lib || mkdir -p $(DESTDIR)$(PREFIX)/lib
-	cp -f build/liblist.a $(DESTDIR)$(PREFIX)/lib/liblist.a
-	cp -f build/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION) $(DESTDIR)$(PREFIX)/lib/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)
-	ln -sf liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION) $(DESTDIR)$(PREFIX)/lib/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION)
-	ln -sf liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION) $(DESTDIR)$(PREFIX)/lib/liblist.so.$(MAJOR_VERSION)
-	ln -sf liblist.so.$(MAJOR_VERSION) $(DESTDIR)$(PREFIX)/lib/liblist.so
+	test -d $(DESTDIR)$(LIBDIR) || mkdir -p $(DESTDIR)$(LIBDIR)
+	cp -f build/liblist.a $(DESTDIR)$(LIBDIR)/liblist.a
+	cp -f build/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION) $(DESTDIR)$(LIBDIR)/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)
+	ln -sf liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION) $(DESTDIR)$(LIBDIR)/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION)
+	ln -sf liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION) $(DESTDIR)$(LIBDIR)/liblist.so.$(MAJOR_VERSION)
+	ln -sf liblist.so.$(MAJOR_VERSION) $(DESTDIR)$(LIBDIR)/liblist.so
 	test -d $(DESTDIR)$(PREFIX)/include || mkdir -p $(DESTDIR)$(PREFIX)/include/
 	cp -f src/list.h $(DESTDIR)$(PREFIX)/include/list.h
 
 uninstall:
-	rm -f $(DESTDIR)$(PREFIX)/lib/liblist.a
+	rm -f $(DESTDIR)$(LIBDIR)/liblist.a
 	rm -f $(DESTDIR)$(PREFIX)/include/list.h
 
 build/liblist.a: $(OBJS)

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 AR ?= ar
 CC ?= gcc
 PREFIX ?= /usr/local
+DESTDIR ?=
 
 CFLAGS = -O3 -std=c99 -Wall -Wextra -Ideps
 
@@ -18,18 +19,18 @@ PATCH_VERSION = 0
 all: build/liblist.a build/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)
 
 install: all
-	test -d $(PREFIX)/lib || mkdir -p $(PREFIX)/lib
-	cp -f build/liblist.a $(PREFIX)/lib/liblist.a
-	cp -f build/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION) $(PREFIX)/lib/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)
-	ln -sf liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION) $(PREFIX)/lib/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION)
-	ln -sf liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION) $(PREFIX)/lib/liblist.so.$(MAJOR_VERSION)
-	ln -sf liblist.so.$(MAJOR_VERSION) $(PREFIX)/lib/liblist.so
-	test -d $(PREFIX)/include || mkdir -p $(PREFIX)/include/
-	cp -f src/list.h $(PREFIX)/include/list.h
+	test -d $(DESTDIR)$(PREFIX)/lib || mkdir -p $(DESTDIR)$(PREFIX)/lib
+	cp -f build/liblist.a $(DESTDIR)$(PREFIX)/lib/liblist.a
+	cp -f build/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION) $(DESTDIR)$(PREFIX)/lib/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)
+	ln -sf liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION) $(DESTDIR)$(PREFIX)/lib/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION)
+	ln -sf liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION) $(DESTDIR)$(PREFIX)/lib/liblist.so.$(MAJOR_VERSION)
+	ln -sf liblist.so.$(MAJOR_VERSION) $(DESTDIR)$(PREFIX)/lib/liblist.so
+	test -d $(DESTDIR)$(PREFIX)/include || mkdir -p $(DESTDIR)$(PREFIX)/include/
+	cp -f src/list.h $(DESTDIR)$(PREFIX)/include/list.h
 
 uninstall:
-	rm -f $(PREFIX)/lib/liblist.a
-	rm -f $(PREFIX)/include/list.h
+	rm -f $(DESTDIR)$(PREFIX)/lib/liblist.a
+	rm -f $(DESTDIR)$(PREFIX)/include/list.h
 
 build/liblist.a: $(OBJS)
 	@mkdir -p build

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ install: all
 
 uninstall:
 	rm -f $(DESTDIR)$(LIBDIR)/liblist.a
+	rm -f $(DESTDIR)$(LIBDIR)/liblist.so
+	rm -f $(DESTDIR)$(LIBDIR)/liblist.so.$(MAJOR_VERSION)
+	rm -f $(DESTDIR)$(LIBDIR)/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION)
+	rm -f $(DESTDIR)$(LIBDIR)/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)
 	rm -f $(DESTDIR)$(INCLUDEDIR)/list.h
 
 build/liblist.a: $(OBJS)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 
 AR ?= ar
 CC ?= gcc
+STRIP ?= strip
 PREFIX ?= /usr/local
 DESTDIR ?=
 
@@ -39,7 +40,7 @@ build/liblist.a: $(OBJS)
 build/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION): $(OBJS)
 	@mkdir -p build
 	ld -z now -shared -lc -soname `basename $@` src/*.o -o $@
-	strip --strip-unneeded --remove-section=.comment --remove-section=.note $@
+	$(STRIP) --strip-unneeded --remove-section=.comment --remove-section=.note $@
 
 bin/test: test.o $(OBJS)
 	@mkdir -p bin


### PR DESCRIPTION
These adjustments provide a little more flexibility for distribution packagers and others who need to:

- customize compiler and linker flags
- do staged installs (i.e., installing to a “buildroot” directory rather than the system root)
- preserve debugging symbols
- customize installation paths