### PR TITLE
Use less generic names for the library when using the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ STRIP ?= strip
 PREFIX ?= /usr/local
 LIBDIR ?= $(PREFIX)/lib
 INCLUDEDIR ?= $(PREFIX)/include
+INCLUDESUBDIR ?= /clibs
 DESTDIR ?=
 
 CFLAGS = -O3 -std=c99 -Wall -Wextra -Ideps
@@ -29,8 +30,8 @@ install: all
 	ln -sf liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION) $(DESTDIR)$(LIBDIR)/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION)
 	ln -sf liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION) $(DESTDIR)$(LIBDIR)/liblist.so.$(MAJOR_VERSION)
 	ln -sf liblist.so.$(MAJOR_VERSION) $(DESTDIR)$(LIBDIR)/liblist.so
-	test -d $(DESTDIR)$(INCLUDEDIR) || mkdir -p $(DESTDIR)$(INCLUDEDIR)/
-	cp -f src/list.h $(DESTDIR)$(INCLUDEDIR)/list.h
+	test -d $(DESTDIR)$(INCLUDEDIR)$(INCLUDESUBDIR) || mkdir -p $(DESTDIR)$(INCLUDEDIR)$(INCLUDESUBDIR)/
+	cp -f src/list.h $(DESTDIR)$(INCLUDEDIR)$(INCLUDESUBDIR)/list.h
 
 uninstall:
 	rm -f $(DESTDIR)$(LIBDIR)/liblist.a
@@ -38,7 +39,7 @@ uninstall:
 	rm -f $(DESTDIR)$(LIBDIR)/liblist.so.$(MAJOR_VERSION)
 	rm -f $(DESTDIR)$(LIBDIR)/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION)
 	rm -f $(DESTDIR)$(LIBDIR)/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)
-	rm -f $(DESTDIR)$(INCLUDEDIR)/list.h
+	rm -f $(DESTDIR)$(INCLUDEDIR)$(INCLUDESUBDIR)/list.h
 
 build/liblist.a: $(OBJS)
 	@mkdir -p build

--- a/Makefile
+++ b/Makefile
@@ -21,31 +21,31 @@ MAJOR_VERSION = 0
 MINOR_VERSION = 2
 PATCH_VERSION = 0
 
-all: build/liblist.a build/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)
+all: build/liblist.a build/libclibs_list.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)
 
 install: all
 	test -d $(DESTDIR)$(LIBDIR) || mkdir -p $(DESTDIR)$(LIBDIR)
 	cp -f build/liblist.a $(DESTDIR)$(LIBDIR)/liblist.a
-	cp -f build/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION) $(DESTDIR)$(LIBDIR)/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)
-	ln -sf liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION) $(DESTDIR)$(LIBDIR)/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION)
-	ln -sf liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION) $(DESTDIR)$(LIBDIR)/liblist.so.$(MAJOR_VERSION)
-	ln -sf liblist.so.$(MAJOR_VERSION) $(DESTDIR)$(LIBDIR)/liblist.so
+	cp -f build/libclibs_list.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION) $(DESTDIR)$(LIBDIR)/libclibs_list.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)
+	ln -sf libclibs_list.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION) $(DESTDIR)$(LIBDIR)/libclibs_list.so.$(MAJOR_VERSION).$(MINOR_VERSION)
+	ln -sf libclibs_list.so.$(MAJOR_VERSION).$(MINOR_VERSION) $(DESTDIR)$(LIBDIR)/libclibs_list.so.$(MAJOR_VERSION)
+	ln -sf libclibs_list.so.$(MAJOR_VERSION) $(DESTDIR)$(LIBDIR)/libclibs_list.so
 	test -d $(DESTDIR)$(INCLUDEDIR)$(INCLUDESUBDIR) || mkdir -p $(DESTDIR)$(INCLUDEDIR)$(INCLUDESUBDIR)/
 	cp -f src/list.h $(DESTDIR)$(INCLUDEDIR)$(INCLUDESUBDIR)/list.h
 
 uninstall:
 	rm -f $(DESTDIR)$(LIBDIR)/liblist.a
-	rm -f $(DESTDIR)$(LIBDIR)/liblist.so
-	rm -f $(DESTDIR)$(LIBDIR)/liblist.so.$(MAJOR_VERSION)
-	rm -f $(DESTDIR)$(LIBDIR)/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION)
-	rm -f $(DESTDIR)$(LIBDIR)/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)
+	rm -f $(DESTDIR)$(LIBDIR)/libclibs_list.so
+	rm -f $(DESTDIR)$(LIBDIR)/libclibs_list.so.$(MAJOR_VERSION)
+	rm -f $(DESTDIR)$(LIBDIR)/libclibs_list.so.$(MAJOR_VERSION).$(MINOR_VERSION)
+	rm -f $(DESTDIR)$(LIBDIR)/libclibs_list.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)
 	rm -f $(DESTDIR)$(INCLUDEDIR)$(INCLUDESUBDIR)/list.h
 
 build/liblist.a: $(OBJS)
 	@mkdir -p build
 	$(AR) rcs $@ $^
 
-build/liblist.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION): $(OBJS)
+build/libclibs_list.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION): $(OBJS)
 	@mkdir -p build
 	$(CC) $(LDFLAGS) -shared -lc -Wl,-soname,`basename $@` src/*.o -o $@
 	$(STRIP) --strip-unneeded --remove-section=.comment --remove-section=.note $@

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,11 @@ MAJOR_VERSION = 0
 MINOR_VERSION = 2
 PATCH_VERSION = 0
 
-all: build/liblist.a build/libclibs_list.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)
+all: build/libclibs_list.a build/libclibs_list.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)
 
 install: all
 	test -d $(DESTDIR)$(LIBDIR) || mkdir -p $(DESTDIR)$(LIBDIR)
-	cp -f build/liblist.a $(DESTDIR)$(LIBDIR)/liblist.a
+	cp -f build/libclibs_list.a $(DESTDIR)$(LIBDIR)/libclibs_list.a
 	cp -f build/libclibs_list.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION) $(DESTDIR)$(LIBDIR)/libclibs_list.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)
 	ln -sf libclibs_list.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION) $(DESTDIR)$(LIBDIR)/libclibs_list.so.$(MAJOR_VERSION).$(MINOR_VERSION)
 	ln -sf libclibs_list.so.$(MAJOR_VERSION).$(MINOR_VERSION) $(DESTDIR)$(LIBDIR)/libclibs_list.so.$(MAJOR_VERSION)
@@ -34,14 +34,14 @@ install: all
 	cp -f src/list.h $(DESTDIR)$(INCLUDEDIR)$(INCLUDESUBDIR)/list.h
 
 uninstall:
-	rm -f $(DESTDIR)$(LIBDIR)/liblist.a
+	rm -f $(DESTDIR)$(LIBDIR)/libclibs_list.a
 	rm -f $(DESTDIR)$(LIBDIR)/libclibs_list.so
 	rm -f $(DESTDIR)$(LIBDIR)/libclibs_list.so.$(MAJOR_VERSION)
 	rm -f $(DESTDIR)$(LIBDIR)/libclibs_list.so.$(MAJOR_VERSION).$(MINOR_VERSION)
 	rm -f $(DESTDIR)$(LIBDIR)/libclibs_list.so.$(MAJOR_VERSION).$(MINOR_VERSION).$(PATCH_VERSION)
 	rm -f $(DESTDIR)$(INCLUDEDIR)$(INCLUDESUBDIR)/list.h
 
-build/liblist.a: $(OBJS)
+build/libclibs_list.a: $(OBJS)
 	@mkdir -p build
 	$(AR) rcs $@ $^
 


### PR DESCRIPTION
This implements the suggestions in https://github.com/clibs/list/issues/38 by making several changes to the `Makefile`:

- Install the header as `$(INCLUDEDIR)/clibs/list.h`, which is normally `$(PREFIX)/include/clibs/list.h`, by default, instead of `$(INCLUDEDIR)/list.h`.
- Rename `liblist.so` to `libclibs_list.so`.
- Rename `liblist.a` to `libclibs_list.a`.

This would reduce the chance of name conflicts in system-wide installations using the `Makefile`. As a result, packages depending on such installations would need to:

- Either change includes from `#include <list.h>` to `#include <clibs/list.h>`, or compile with e.g. `-I/usr/include/clibs`.
- Link against the shared library with `-lclibs_list` instead of `-llist`.
- Link the static library with e.g. `/usr/lib64/libclibs_list.a` instead of `/usr/lib64/liblist.a`.

I don’t think any changes to the `Makefile` should affect `clib` users, but I am not a `clib` user, so I would appreciate verification of this.

After this PR:

```
$ make
cc src/list.c -O3 -std=c99 -Wall -Wextra -Ideps -c -o src/list.o
cc src/list_node.c -O3 -std=c99 -Wall -Wextra -Ideps -c -o src/list_node.o
cc src/list_iterator.c -O3 -std=c99 -Wall -Wextra -Ideps -c -o src/list_iterator.o
ar rcs build/libclibs_list.a src/list.o src/list_node.o src/list_iterator.o
cc -Wl,-z,now -shared -lc -Wl,-soname,`basename build/libclibs_list.so.0.2.0` src/*.o -o build/libclibs_list.so.0.2.0
strip --strip-unneeded --remove-section=.comment --remove-section=.note build/libclibs_list.so.0.2.0
$ ls build/
libclibs_list.a  libclibs_list.so.0.2.0
$ objdump -x build/libclibs_list.so.0.2.0 | grep SONAME
  SONAME               libclibs_list.so.0.2.0
$ make install DESTDIR=tmpdir
test -d tmpdir/usr/local/lib || mkdir -p tmpdir/usr/local/lib
cp -f build/libclibs_list.a tmpdir/usr/local/lib/libclibs_list.a
cp -f build/libclibs_list.so.0.2.0 tmpdir/usr/local/lib/libclibs_list.so.0.2.0
ln -sf libclibs_list.so.0.2.0 tmpdir/usr/local/lib/libclibs_list.so.0.2
ln -sf libclibs_list.so.0.2 tmpdir/usr/local/lib/libclibs_list.so.0
ln -sf libclibs_list.so.0 tmpdir/usr/local/lib/libclibs_list.so
test -d tmpdir/usr/local/include/clibs || mkdir -p tmpdir/usr/local/include/clibs/
cp -f src/list.h tmpdir/usr/local/include/clibs/list.h
$ find tmpdir/ ! -type d
tmpdir/usr/local/lib/libclibs_list.a
tmpdir/usr/local/lib/libclibs_list.so.0.2.0
tmpdir/usr/local/lib/libclibs_list.so.0.2
tmpdir/usr/local/lib/libclibs_list.so.0
tmpdir/usr/local/lib/libclibs_list.so
tmpdir/usr/local/include/clibs/list.h
```