### PR TITLE
test: Fix type of User_equal

### DIFF
--- a/test.c
+++ b/test.c
@@ -25,7 +25,9 @@ typedef struct {
 } User;
 
 static int
-User_equal(User *a, User *b) {
+User_equal(void *a1, void *b1) {
+  User *a = a1;
+  User *b = b1;
   return 0 == strcmp(a->name, b->name);
 }
 


### PR DESCRIPTION
The match function has `void *` arguments, not `User *` arguments. This avoids an implicit function pointer type conversion in test_list_find, which is not accepted by all compilers anymore.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
